### PR TITLE
Fix binary search midpoint overflow

### DIFF
--- a/mylab/src/utils/geom.ts
+++ b/mylab/src/utils/geom.ts
@@ -14,7 +14,11 @@ export function rectFromKF(kf: Keyframe): RectPX {
 export function findKFIndexAtOrBefore(kfs: Keyframe[], f: number): number {
   let lo = 0, hi = kfs.length - 1, ans = -1;
   while (lo <= hi) {
-    const mid = (lo + hi) >> 1;
+    // Use Math.floor instead of bitwise shift to avoid 32-bit overflow
+    // when dealing with large indices. Bitwise operators convert numbers
+    // to signed 32-bit integers, which could yield incorrect midpoints
+    // for arrays longer than 2^31 entries.
+    const mid = Math.floor((lo + hi) / 2);
     if (kfs[mid].frame <= f) { ans = mid; lo = mid + 1; } else hi = mid - 1;
   }
   return ans;


### PR DESCRIPTION
## Summary
- avoid 32-bit overflow in `findKFIndexAtOrBefore`

## Testing
- `npm run lint` *(fails: prefer-const, ban-ts-comment, etc.)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0df7a023c8326bb02c189d22f455d