### PR TITLE
Fix next keyframe navigation when no prior keyframe

### DIFF
--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -491,7 +491,12 @@ const SequenceLabeler: React.FC<{
     if (!oneSelected) return;
     const kfs = oneSelected.keyframes;
     const idx = findKFIndexAtOrBefore(kfs, frame);
-    const next = (idx >= 0 && idx < kfs.length - 1) ? kfs[idx + 1].frame : kfs[kfs.length - 1].frame;
+    // If no keyframe exists at or before the current frame (idx === -1),
+    // jump to the first keyframe instead of wrapping to the last.
+    // Otherwise move to the next keyframe, or stay on the last one if already there.
+    const next = (idx === -1)
+      ? kfs[0].frame
+      : (idx < kfs.length - 1 ? kfs[idx + 1].frame : kfs[kfs.length - 1].frame);
     setFrame(next);
   }
   function togglePresenceAtCurrent() {


### PR DESCRIPTION
## Summary
- Ensure `gotoNextKeyframe` jumps to the first keyframe when there is no keyframe at or before the current frame
- Document this edge case with explanatory comments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 20 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e0946f388326ad3b48fce0acd87c