### PR TITLE
Use single-line empty tracks message

### DIFF
--- a/mylab/src/components/TrackPanel.tsx
+++ b/mylab/src/components/TrackPanel.tsx
@@ -62,7 +62,11 @@ const TrackPanel: React.FC<Props> = ({ labelSet, tracks, selectedIds, setSelecte
           </div>
         );
       })}
-      {!tracks.length && <div style={{ opacity: 0.7, fontSize: 12 }}>캔버스를 드래그해 새 트랙을 만드세요. Alt+드래그=다중 이동(선택된 트랙)</div>}
+      {!tracks.length && (
+        <div style={{ opacity: 0.7, fontSize: 12 }}>
+          캔버스를 드래그해 새 트랙을 만드세요. Alt+드래그=다중 이동(선택된 트랙)
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- keep empty tracks hint on one line

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 21 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e09317a88326a05e95c4cd43824f