### PR TITLE
Fix module header in transt wrapper

### DIFF
--- a/Docker/transt_wrapper.py
+++ b/Docker/transt_wrapper.py
@@ -1,4 +1,4 @@
-# tracker_wrapper.py
+# transt_wrapper.py: Wrapper and session service for the Transt tracker
 import base64
 import threading
 import time


### PR DESCRIPTION
## Summary
- fix top comment in transt_wrapper to correctly describe module

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e09558a48326be84af05cc49d824