### PR TITLE
Reduce left panel width

### DIFF
--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -649,9 +649,9 @@ const SequenceLabeler: React.FC<{
       </div>
 
       {/* Middle: Left panel + Canvas */}
-      <div style={{ display: "grid", gridTemplateColumns: "minmax(300px, 36vw) 1fr", minHeight: 0 }}>
+      <div style={{ display: "grid", gridTemplateColumns: "minmax(240px, 25vw) 1fr", minHeight: 0 }}>
         {/* Left panel */}
-        <div style={{ borderRight: "1px solid #222", padding: 8, overflow: "auto", minWidth: 300 }}>
+        <div style={{ borderRight: "1px solid #222", padding: 8, overflow: "auto", minWidth: 240 }}>
           {/* Label set */}
           <div style={{ marginBottom: 10 }}>
             <div style={{ fontWeight: 600, marginBottom: 6 }}>Label Set</div>


### PR DESCRIPTION
## Summary
- Shrink sequence labeler left panel width, freeing more room for the canvas.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0e771609c8326930184097162350b