### PR TITLE
feat: add project and task management

### DIFF
--- a/mylab/src/App.tsx
+++ b/mylab/src/App.tsx
@@ -1,15 +1,84 @@
+import React, { useRef, useState } from "react";
 import SequenceLabeler from "./SequenceLabeler/SequenceLabeler";
+import ProjectManager from "./lib/ProjectManager";
+import type { Project, Task } from "./types";
 
 export default function App() {
+  const pm = useRef(new ProjectManager());
+  const [projects, setProjects] = useState<Project[]>(pm.current.getProjects());
+  const [currentProject, setCurrentProject] = useState<Project | null>(projects[0] ?? null);
+  const [currentTask, setCurrentTask] = useState<Task | null>(currentProject?.tasks[0] ?? null);
+
+  const refresh = () => setProjects([...pm.current.getProjects()]);
+
+  const handleCreateProject = () => {
+    const name = prompt("Project name?");
+    if (name) {
+      const p = pm.current.createProject(name);
+      refresh();
+      setCurrentProject(p);
+      setCurrentTask(null);
+    }
+  };
+
+  const handleCreateTask = () => {
+    if (!currentProject) return;
+    const name = prompt("Task name?");
+    const folder = prompt("Work folder?");
+    if (name && folder) {
+      const t = pm.current.addTask(currentProject.id, name, folder);
+      refresh();
+      setCurrentTask(t);
+    }
+  };
+
+  const selectProject = (id: string) => {
+    const p = pm.current.getProjects().find(p => p.id === id) ?? null;
+    setCurrentProject(p);
+    setCurrentTask(null);
+  };
+
+  const selectTask = (t: Task) => setCurrentTask(t);
+
   return (
-    <div style={{height:"100vh"}}>
-      <SequenceLabeler
-        framesBaseUrl="/dataset/frames"
-        indexUrl="/dataset/index.json"
-        initialLabelSetName="Default"
-        defaultClasses={["Person","Car","Button","Enemy"]}
-        prefetchRadius={8}
-      />
+    <div style={{ height: "100vh", display: "flex" }}>
+      <div style={{ width: 250, borderRight: "1px solid #ccc", padding: 8, overflowY: "auto" }}>
+        <button onClick={handleCreateProject}>New Project</button>
+        <ul>
+          {projects.map(p => (
+            <li key={p.id}>
+              <button onClick={() => selectProject(p.id)} style={{ fontWeight: p.id === currentProject?.id ? "bold" : "normal" }}>{p.name}</button>
+            </li>
+          ))}
+        </ul>
+        {currentProject && (
+          <div>
+            <h4>Tasks</h4>
+            <button onClick={handleCreateTask}>New Task</button>
+            <ul>
+              {currentProject.tasks.map(t => (
+                <li key={t.id}>
+                  <button onClick={() => selectTask(t)} style={{ fontWeight: t.id === currentTask?.id ? "bold" : "normal" }}>{t.name}</button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+      <div style={{ flex: 1 }}>
+        {currentTask ? (
+          <SequenceLabeler
+            framesBaseUrl={`${currentTask.workFolder}/frames`}
+            indexUrl={`${currentTask.workFolder}/index.json`}
+            taskId={currentTask.id}
+            initialLabelSetName="Default"
+            defaultClasses={["Person", "Car", "Button", "Enemy"]}
+            prefetchRadius={8}
+          />
+        ) : (
+          <div style={{ padding: 16 }}>Select a task.</div>
+        )}
+      </div>
     </div>
   );
 }

--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -14,6 +14,7 @@ import { eventToKeyString, normalizeKeyString } from "../utils/keys";
 const SequenceLabeler: React.FC<{
   framesBaseUrl: string;
   indexUrl: string;
+  taskId?: string;
   initialLabelSetName?: string;
   defaultClasses: string[];
   prefetchRadius?: number;
@@ -21,6 +22,7 @@ const SequenceLabeler: React.FC<{
 }> = ({
   framesBaseUrl,
   indexUrl,
+  taskId,
   initialLabelSetName = "Default",
   defaultClasses,
   prefetchRadius = 8,
@@ -89,8 +91,9 @@ const SequenceLabeler: React.FC<{
     "copy_tracks": "Ctrl+c",
     "paste_tracks": "Ctrl+v"
   };
+  const storagePrefix = taskId ?? indexUrl;
   const [keymap, setKeymap] = useState<KeyMap>(() => {
-    const raw = localStorage.getItem(`${indexUrl}::keymap_v2`);
+    const raw = localStorage.getItem(`${storagePrefix}::keymap_v2`);
     return raw ? JSON.parse(raw) : DEFAULT_KEYMAP;
   });
   const [keyUIOpen, setKeyUIOpen] = useState(false);
@@ -102,7 +105,7 @@ const SequenceLabeler: React.FC<{
 
   /** ===== Restore & Load ===== */
   useEffect(() => {
-    const raw = localStorage.getItem(`${indexUrl}::autosave_v2`);
+    const raw = localStorage.getItem(`${storagePrefix}::autosave_v2`);
     if (raw) {
       try {
         const s = JSON.parse(raw);
@@ -112,7 +115,7 @@ const SequenceLabeler: React.FC<{
         if (typeof s.interpolate === "boolean") setInterpolate(s.interpolate);
       } catch {}
     }
-  }, [indexUrl]);
+  }, [storagePrefix]);
 
   useEffect(() => {
     let aborted = false;
@@ -145,13 +148,13 @@ const SequenceLabeler: React.FC<{
 
   useEffect(() => {
     const t = setTimeout(() => {
-      localStorage.setItem(`${indexUrl}::autosave_v2`, JSON.stringify({
+      localStorage.setItem(`${storagePrefix}::autosave_v2`, JSON.stringify({
         schema: DEFAULT_SCHEMA, version: DEFAULT_VERSION,
         meta, labelSet, tracks, frame, interpolate
       }));
     }, 300);
     return () => clearTimeout(t);
-  }, [meta, labelSet, tracks, frame, interpolate, indexUrl]);
+  }, [meta, labelSet, tracks, frame, interpolate, storagePrefix]);
 
   // observe timeline width
   useEffect(() => {

--- a/mylab/src/lib/ProjectManager.ts
+++ b/mylab/src/lib/ProjectManager.ts
@@ -1,4 +1,4 @@
-import { Project, Task } from "../types";
+import type { Project, Task } from "../types";
 import { uuid } from "../utils/geom";
 
 const STORAGE_KEY = "projects_v1";

--- a/mylab/src/lib/ProjectManager.ts
+++ b/mylab/src/lib/ProjectManager.ts
@@ -1,0 +1,66 @@
+import { Project, Task } from "../types";
+import { uuid } from "../utils/geom";
+
+const STORAGE_KEY = "projects_v1";
+
+export default class ProjectManager {
+  private projects: Project[] = [];
+
+  constructor() {
+    this.load();
+  }
+
+  private load() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      try {
+        this.projects = JSON.parse(raw);
+      } catch {
+        this.projects = [];
+      }
+    }
+  }
+
+  private save() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(this.projects));
+  }
+
+  getProjects(): Project[] {
+    return this.projects;
+  }
+
+  createProject(name: string): Project {
+    const project: Project = { id: uuid(), name, tasks: [] };
+    this.projects.push(project);
+    this.save();
+    return project;
+    }
+
+  addTask(projectId: string, name: string, workFolder: string): Task {
+    const project = this.projects.find(p => p.id === projectId);
+    if (!project) throw new Error("Project not found");
+    const task: Task = { id: uuid(), name, workFolder };
+    project.tasks.push(task);
+    this.save();
+    return task;
+  }
+
+  updateTaskFolder(taskId: string, folder: string) {
+    for (const p of this.projects) {
+      const t = p.tasks.find(t => t.id === taskId);
+      if (t) {
+        t.workFolder = folder;
+        this.save();
+        return;
+      }
+    }
+  }
+
+  getTask(taskId: string): Task | undefined {
+    for (const p of this.projects) {
+      const t = p.tasks.find(t => t.id === taskId);
+      if (t) return t;
+    }
+    return undefined;
+  }
+}

--- a/mylab/src/types.ts
+++ b/mylab/src/types.ts
@@ -31,3 +31,15 @@ export type KeyMap = Record<string, string>; // action -> key string
 export type LocalFile = { name: string; handle: FileSystemFileHandle; url: string };
 
 export type Handle = "none" | "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw" | "move";
+
+export type Task = {
+  id: string;
+  name: string;
+  workFolder: string; // path to task workspace
+};
+
+export type Project = {
+  id: string;
+  name: string;
+  tasks: Task[];
+};


### PR DESCRIPTION
## Summary
- add Task and Project types and a ProjectManager utility to manage them
- allow SequenceLabeler to store keymap and labels per task via taskId
- provide simple UI in App to create projects and tasks and select work folders

## Testing
- `npm test`
- `npm run lint` *(fails: prefer-const, ban-ts-comment, no-explicit-any, no-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fa06e8c48326b35fb78ad38b051e