### PR TITLE
feat: add project and task management

### DIFF
--- a/mylab/src/App.tsx
+++ b/mylab/src/App.tsx
@@ -1,15 +1,135 @@
+import React, { useRef, useState } from "react";
 import SequenceLabeler from "./SequenceLabeler/SequenceLabeler";
+import ProjectManager from "./lib/ProjectManager";
+import type { Project, Task } from "./types";
 
 export default function App() {
+  const pm = useRef(new ProjectManager());
+  const [projects, setProjects] = useState<Project[]>(pm.current.getProjects());
+  const [currentProject, setCurrentProject] = useState<Project | null>(projects[0] ?? null);
+  const [currentTask, setCurrentTask] = useState<Task | null>(currentProject?.tasks[0] ?? null);
+  const [panelOpen, setPanelOpen] = useState(true);
+
+  const refresh = () => setProjects([...pm.current.getProjects()]);
+
+  const handleCreateProject = () => {
+    const name = prompt("Project name?");
+    if (name) {
+      const p = pm.current.createProject(name);
+      refresh();
+      setCurrentProject(p);
+      setCurrentTask(null);
+    }
+  };
+
+  const handleCreateTask = () => {
+    if (!currentProject) return;
+    const name = prompt("Task name?");
+    if (!name) return;
+    const input = document.createElement("input");
+    input.type = "file";
+    input.setAttribute("webkitdirectory", "true");
+    input.onchange = () => {
+      const files = input.files;
+      if (!files || !files.length) return;
+      const file = files[0] as File & { path?: string; webkitRelativePath?: string };
+      const fullPath = file.path ?? file.webkitRelativePath ?? "";
+      const folder = fullPath.split(/[/\\]/).slice(0, -1).join("/");
+      if (folder) {
+        const t = pm.current.addTask(currentProject.id, name, folder);
+        refresh();
+        setCurrentTask(t);
+      }
+    };
+    input.click();
+  };
+
+  const selectProject = (id: string) => {
+    const p = pm.current.getProjects().find(p => p.id === id) ?? null;
+    setCurrentProject(p);
+    setCurrentTask(null);
+  };
+
+  const selectTask = (t: Task) => setCurrentTask(t);
+
+  const handleDeleteProject = (id: string) => {
+    pm.current.deleteProject(id);
+    refresh();
+    if (currentProject?.id === id) {
+      const remaining = pm.current.getProjects();
+      const p = remaining[0] ?? null;
+      setCurrentProject(p);
+      setCurrentTask(p?.tasks[0] ?? null);
+    }
+  };
+
+  const handleDeleteTask = (projectId: string, taskId: string) => {
+    pm.current.deleteTask(projectId, taskId);
+    refresh();
+    if (currentTask?.id === taskId) {
+      setCurrentTask(null);
+    }
+  };
+
   return (
-    <div style={{height:"100vh"}}>
-      <SequenceLabeler
-        framesBaseUrl="/dataset/frames"
-        indexUrl="/dataset/index.json"
-        initialLabelSetName="Default"
-        defaultClasses={["Person","Car","Button","Enemy"]}
-        prefetchRadius={8}
-      />
+    <div style={{ height: "100vh", display: "flex", position: "relative" }}>
+      {panelOpen && (
+        <div style={{ width: 250, borderRight: "1px solid #ccc", padding: 8, overflowY: "auto" }}>
+          <button onClick={handleCreateProject}>New Project</button>
+          <ul>
+            {projects.map(p => (
+              <li key={p.id}>
+                <button
+                  onClick={() => selectProject(p.id)}
+                  style={{ fontWeight: p.id === currentProject?.id ? "bold" : "normal" }}
+                >
+                  {p.name}
+                </button>
+                <button onClick={() => handleDeleteProject(p.id)} style={{ marginLeft: 4 }}>✕</button>
+              </li>
+            ))}
+          </ul>
+          {currentProject && (
+            <div>
+              <h4>Tasks</h4>
+              <button onClick={handleCreateTask}>New Task</button>
+              <ul>
+                {currentProject.tasks.map(t => (
+                  <li key={t.id}>
+                    <button
+                      onClick={() => selectTask(t)}
+                      style={{ fontWeight: t.id === currentTask?.id ? "bold" : "normal" }}
+                    >
+                      {t.name}
+                    </button>
+                    <button onClick={() => handleDeleteTask(currentProject.id, t.id)} style={{ marginLeft: 4 }}>✕</button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+      <div style={{ flex: 1, marginLeft: panelOpen ? 0 : 32 }}>
+        {currentTask ? (
+          <SequenceLabeler
+            framesBaseUrl={`${currentTask.workFolder}/frames`}
+            indexUrl={`${currentTask.workFolder}/index.json`}
+            taskId={currentTask.id}
+            initialLabelSetName="Default"
+            defaultClasses={["Person", "Car", "Button", "Enemy"]}
+            prefetchRadius={8}
+          />
+        ) : (
+          <div style={{ padding: 16 }}>Select a task.</div>
+        )}
+      </div>
+      <button
+        onClick={() => setPanelOpen(o => !o)}
+        style={{ position: "absolute", top: 8, left: panelOpen ? 258 : 8 }}
+      >
+        {panelOpen ? "⮜" : "⮞"}
+      </button>
     </div>
   );
 }

--- a/mylab/src/lib/ProjectManager.ts
+++ b/mylab/src/lib/ProjectManager.ts
@@ -1,0 +1,78 @@
+import { Project, Task } from "../types";
+import { uuid } from "../utils/geom";
+
+const STORAGE_KEY = "projects_v1";
+
+export default class ProjectManager {
+  private projects: Project[] = [];
+
+  constructor() {
+    this.load();
+  }
+
+  private load() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      try {
+        this.projects = JSON.parse(raw);
+      } catch {
+        this.projects = [];
+      }
+    }
+  }
+
+  private save() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(this.projects));
+  }
+
+  getProjects(): Project[] {
+    return this.projects;
+  }
+
+  createProject(name: string): Project {
+    const project: Project = { id: uuid(), name, tasks: [] };
+    this.projects.push(project);
+    this.save();
+    return project;
+    }
+
+  addTask(projectId: string, name: string, workFolder: string): Task {
+    const project = this.projects.find(p => p.id === projectId);
+    if (!project) throw new Error("Project not found");
+    const task: Task = { id: uuid(), name, workFolder };
+    project.tasks.push(task);
+    this.save();
+    return task;
+  }
+
+  deleteProject(projectId: string) {
+    this.projects = this.projects.filter(p => p.id !== projectId);
+    this.save();
+  }
+
+  deleteTask(projectId: string, taskId: string) {
+    const project = this.projects.find(p => p.id === projectId);
+    if (!project) return;
+    project.tasks = project.tasks.filter(t => t.id !== taskId);
+    this.save();
+  }
+
+  updateTaskFolder(taskId: string, folder: string) {
+    for (const p of this.projects) {
+      const t = p.tasks.find(t => t.id === taskId);
+      if (t) {
+        t.workFolder = folder;
+        this.save();
+        return;
+      }
+    }
+  }
+
+  getTask(taskId: string): Task | undefined {
+    for (const p of this.projects) {
+      const t = p.tasks.find(t => t.id === taskId);
+      if (t) return t;
+    }
+    return undefined;
+  }
+}

--- a/mylab/src/types.ts
+++ b/mylab/src/types.ts
@@ -31,3 +31,15 @@ export type KeyMap = Record<string, string>; // action -> key string
 export type LocalFile = { name: string; handle: FileSystemFileHandle; url: string };
 
 export type Handle = "none" | "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw" | "move";
+
+export type Task = {
+  id: string;
+  name: string;
+  workFolder: string; // path to task workspace
+};
+
+export type Project = {
+  id: string;
+  name: string;
+  tasks: Task[];
+};


### PR DESCRIPTION
## Summary
- add Task and Project types and a ProjectManager utility to manage them
- allow SequenceLabeler to store keymap and labels per task via taskId
- provide simple UI in App to create, delete, and launch task work folders
- make project panel collapsible, adjust toggle placement, and pick task folders via directory dialog
- remove Import Folder button from SequenceLabeler and clean up lint issues

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0fa06e8c48326b35fb78ad38b051e