### PR TITLE
Fix task folder path detection so images load

### DIFF
--- a/mylab/src/App.tsx
+++ b/mylab/src/App.tsx
@@ -33,8 +33,16 @@ export default function App() {
       const files = input.files;
       if (!files || !files.length) return;
       const file = files[0] as File & { path?: string; webkitRelativePath?: string };
-      const fullPath = file.path ?? file.webkitRelativePath ?? "";
-      const folder = fullPath.split(/[/\\]/).slice(0, -1).join("/");
+      const relPath = file.webkitRelativePath ?? "";
+      let folder = "";
+      if (file.path && relPath) {
+        const base = file.path.slice(0, file.path.length - relPath.length);
+        const top = relPath.split(/[/\\]/)[0];
+        folder = `${base}${top}`.replace(/\\/g, "/").replace(/\/$/, "");
+      } else if (relPath) {
+        // webkitRelativePath includes the top-level directory selected by the user
+        folder = relPath.split(/[/\\]/)[0];
+      }
       if (folder) {
         const t = pm.current.addTask(currentProject.id, name, folder);
         refresh();


### PR DESCRIPTION
## Summary
- Correct task directory detection when creating tasks to use selected top-level folder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1657c6d5c8326a8f113c11c79db83