### PR TITLE
Add timeline keyframe icons and navigation buttons

### DIFF
--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -778,6 +778,12 @@ const SequenceLabeler: React.FC<{
             )}
           </div>
           <div ref={timelineWrapRef} style={{ padding: "6px 12px", borderTop: "1px solid #222" }}>
+            <div style={{ display: "flex", gap: 6, marginBottom: 4, flexWrap: "wrap" }}>
+              <button onClick={() => setFrame(f => clamp(f - 1, 0, totalFrames - 1))}>Prev</button>
+              <button onClick={() => setFrame(f => clamp(f + 1, 0, totalFrames - 1))}>Next</button>
+              <button onClick={gotoPrevKeyframe} disabled={!oneSelected || oneSelected.keyframes.length === 0}>Prev KF</button>
+              <button onClick={gotoNextKeyframe} disabled={!oneSelected || oneSelected.keyframes.length === 0}>Next KF</button>
+            </div>
             <Timeline
               total={totalFrames || 1}
               frame={frame}

--- a/mylab/src/components/Timeline.tsx
+++ b/mylab/src/components/Timeline.tsx
@@ -67,7 +67,10 @@ const Timeline: React.FC<{
       })}
       <line x1={margin} y1={margin + innerH / 2} x2={margin + innerW} y2={margin + innerH / 2} stroke="#555" />
       {[...kfFrames].map((f, i) => (
-        <line key={`kf-${i}`} x1={scaleX(f)} x2={scaleX(f)} y1={margin} y2={margin + innerH} stroke="#4ea3ff" strokeWidth={2} />
+        <g key={`kf-${i}`}>
+          <line x1={scaleX(f)} x2={scaleX(f)} y1={margin} y2={margin + innerH} stroke="#4ea3ff" strokeWidth={2} />
+          <circle cx={scaleX(f)} cy={margin / 2} r={3} fill="#4ea3ff" />
+        </g>
       ))}
       {[...toggleFrames].map((f, i) => {
         const x = scaleX(f), y = margin;


### PR DESCRIPTION
## Summary
- Show small circles above keyframe positions on the timeline for better visibility
- Add frame and keyframe navigation buttons near the timeline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a166ce92448326b5b43d9e9e37f84b