### PR TITLE
Fix task folder detection using actual file path

### DIFF
--- a/mylab/src/App.tsx
+++ b/mylab/src/App.tsx
@@ -33,13 +33,15 @@ export default function App() {
       const files = input.files;
       if (!files || !files.length) return;
       const file = files[0] as File & { path?: string; webkitRelativePath?: string };
-      const fullPath = file.path ?? file.webkitRelativePath ?? "";
-      const folder = fullPath.split(/[/\\]/).slice(0, -1).join("/");
-      if (folder) {
-        const t = pm.current.addTask(currentProject.id, name, folder);
-        refresh();
-        setCurrentTask(t);
-      }
+      if (!file.path) return;
+      const relPath = file.webkitRelativePath ?? "";
+      const folder = file.path
+        .slice(0, file.path.length - relPath.length)
+        .replace(/\\/g, "/")
+        .replace(/\/$/, "");
+      const t = pm.current.addTask(currentProject.id, name, folder);
+      refresh();
+      setCurrentTask(t);
     };
     input.click();
   };


### PR DESCRIPTION
## Summary
- Derive task root folder directly from file path and strip trailing slashes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1657c6d5c8326a8f113c11c79db83