### PR TITLE
Handle invalid JSON responses when loading frame index

### DIFF
--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -122,24 +122,39 @@ const SequenceLabeler: React.FC<{
   useEffect(() => {
     let aborted = false;
     (async () => {
-      const r = await fetch(indexUrl);
-      if (!r.ok) throw new Error(`index fetch ${r.status}`);
-      const m: IndexMeta = await r.json();
-      if (aborted) return;
-      setMeta(m);
-      if (m.files?.length) setFiles(m.files);
-      else {
-        const padW = m.zeroPad ?? Math.max(6, String(Math.max(0, m.count - 1)).length);
-        const ext = m.ext ?? "webp";
-        setFiles(Array.from({ length: m.count }, (_, i) => `frame_${pad(i, padW)}.${ext}`));
+      try {
+        const r = await fetch(indexUrl);
+        if (!r.ok) throw new Error(`index fetch ${r.status}`);
+
+        const raw = await r.text();
+        let m: IndexMeta;
+        try {
+          m = JSON.parse(raw) as IndexMeta;
+        } catch (err) {
+          console.error("index meta parse error", err, {
+            contentType: r.headers.get("content-type"),
+            bodyPreview: raw.slice(0, 200)
+          });
+          return;
+        }
+        if (aborted) return;
+        setMeta(m);
+        if (m.files?.length) setFiles(m.files);
+        else {
+          const padW = m.zeroPad ?? Math.max(6, String(Math.max(0, m.count - 1)).length);
+          const ext = m.ext ?? "webp";
+          setFiles(Array.from({ length: m.count }, (_, i) => `frame_${pad(i, padW)}.${ext}`));
+        }
+        setTimeout(() => {
+          if (!canvasWrapRef.current || !m) return;
+          const { width } = canvasWrapRef.current.getBoundingClientRect();
+          const max = width / m.width;
+          setScale(Math.min(1, max));
+        }, 0);
+      } catch (err) {
+        console.error(err);
       }
-      setTimeout(() => {
-        if (!canvasWrapRef.current || !m) return;
-        const { width } = canvasWrapRef.current.getBoundingClientRect();
-        const max = width / m.width;
-        setScale(Math.min(1, max));
-      }, 0);
-    })().catch(console.error);
+    })();
     return () => { aborted = true; };
   }, [indexUrl]);
 


### PR DESCRIPTION
## Summary
- avoid crashing when the index URL returns non-JSON content by parsing manually and logging errors
- include response content-type and a preview of the response body when parsing fails

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1676d49f0832680a90816e5ec71d4