### PR TITLE
feat: reintroduce components folder imports

### DIFF
--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DEFAULT_SCHEMA, DEFAULT_VERSION } from "../constants";
 import LRUFrames from "../lib/LRUFrames";
-import Timeline from "../components/Timeline";
-import TrackPanel from "../components/TrackPanel";
-import ShortcutModal from "../components/ShortcutModal";
+import { Timeline, TrackPanel, ShortcutModal } from "../components";
 import type { IndexMeta, RectPX, Track, LabelSet, KeyMap, LocalFile, Handle } from "../types";
 import {
   clamp, pad, uuid, rectAtFrame, handleAt,

--- a/mylab/src/components/index.ts
+++ b/mylab/src/components/index.ts
@@ -1,0 +1,3 @@
+export { default as ShortcutModal } from './ShortcutModal';
+export { default as Timeline } from './Timeline';
+export { default as TrackPanel } from './TrackPanel';


### PR DESCRIPTION
## Summary
- add component barrel file for folder-level imports
- consolidate SequenceLabeler imports via new barrel file

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16a0789948326b204c5844f3002fa