### PR TITLE
fix: allow creating tasks without file path

### DIFF
--- a/mylab/src/App.tsx
+++ b/mylab/src/App.tsx
@@ -150,6 +150,10 @@ export default function App() {
             initialLabelSetName="Default"
             defaultClasses={["Person", "Car", "Button", "Enemy"]}
             prefetchRadius={8}
+            onFolderImported={folder => {
+              pm.current.updateTaskFolder(currentTask.id, folder);
+              refresh();
+            }}
           />
         ) : (
           <div style={{ padding: 16 }}>Select a task.</div>

--- a/mylab/src/App.tsx
+++ b/mylab/src/App.tsx
@@ -28,17 +28,24 @@ export default function App() {
     if (!name) return;
     const input = document.createElement("input");
     input.type = "file";
+    // allow directory selection in Chromium based browsers
     input.setAttribute("webkitdirectory", "true");
     input.onchange = () => {
       const files = input.files;
       if (!files || !files.length) return;
       const file = files[0] as File & { path?: string; webkitRelativePath?: string };
-      if (!file.path) return;
       const relPath = file.webkitRelativePath ?? "";
-      const folder = file.path
-        .slice(0, file.path.length - relPath.length)
-        .replace(/\\/g, "/")
-        .replace(/\/$/, "");
+      const fullPath = file.path ?? "";
+      let folder = "";
+      if (fullPath) {
+        // Browsers like Electron expose the absolute path via file.path
+        folder = fullPath.slice(0, fullPath.length - relPath.length)
+          .replace(/\\/g, "/")
+          .replace(/\/$/, "");
+      } else {
+        // Fallback: derive top-level folder from relative path so task can still be added
+        folder = relPath.split("/")[0] ?? "";
+      }
       const t = pm.current.addTask(currentProject.id, name, folder);
       refresh();
       setCurrentTask(t);

--- a/mylab/src/App.tsx
+++ b/mylab/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import SequenceLabeler from "./SequenceLabeler/SequenceLabeler";
+import SequenceLabeler from "./SequenceLabeler";
 import ProjectManager from "./lib/ProjectManager";
 import type { Project, Task } from "./types";
 

--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -4,8 +4,13 @@ import LRUFrames from "../lib/LRUFrames";
 import { Timeline, TrackPanel, ShortcutModal } from "../components";
 import type { IndexMeta, RectPX, Track, LabelSet, KeyMap, LocalFile, Handle } from "../types";
 import {
-  clamp, pad, uuid, rectAtFrame, handleAt,
-  findKFIndexAtOrBefore
+  clamp,
+  pad,
+  uuid,
+  rectAtFrame,
+  handleAt,
+  findKFIndexAtOrBefore,
+  parseNumericKey
 } from "../utils/geom";
 import { eventToKeyString, normalizeKeyString } from "../utils/keys";
 
@@ -29,7 +34,7 @@ const SequenceLabeler: React.FC<{
   // media
   const [meta, setMeta] = useState<IndexMeta | null>(null);
   const [files, setFiles] = useState<string[]>([]);
-  const [localFiles] = useState<LocalFile[] | null>(null);
+  const [localFiles, setLocalFiles] = useState<LocalFile[] | null>(null);
   const [frame, setFrame] = useState(0);
   const [scale, setScale] = useState(1);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -660,6 +665,60 @@ const SequenceLabeler: React.FC<{
     alert("YOLO 내보내기 완료");
   }
 
+  async function importFolder() {
+    if (!('showDirectoryPicker' in window)) {
+      alert('Chromium 계열 브라우저에서 사용하세요.');
+      return;
+    }
+    const dir: FileSystemDirectoryHandle = await (window as unknown as {
+      showDirectoryPicker: (opts: { id: string }) => Promise<FileSystemDirectoryHandle>;
+    }).showDirectoryPicker({ id: 'frames-folder' });
+    const entries: LocalFile[] = [];
+    // @ts-ignore
+    for await (const entry of (dir as any).values()) {
+      if (entry.kind === 'file') {
+        const name = String(entry.name);
+        if (!/\.(png|jpg|jpeg|webp)$/i.test(name)) continue;
+        const file = await entry.getFile();
+        const url = URL.createObjectURL(file);
+        entries.push({ name, handle: entry, url });
+      }
+    }
+    if (!entries.length) {
+      alert('이미지 파일이 없습니다.');
+      return;
+    }
+    entries.sort((a, b) => {
+      const na = parseNumericKey(a.name);
+      const nb = parseNumericKey(b.name);
+      if (Number.isNaN(na) && Number.isNaN(nb)) return a.name.localeCompare(b.name);
+      if (Number.isNaN(na)) return 1;
+      if (Number.isNaN(nb)) return -1;
+      return na - nb;
+    });
+
+    const first = await entries[0].handle.getFile();
+    const bmp = await createImageBitmap(first);
+    const m: IndexMeta = {
+      width: bmp.width,
+      height: bmp.height,
+      fps: 30,
+      count: entries.length,
+      files: entries.map(e => e.name)
+    };
+    setMeta(m);
+    setLocalFiles(entries);
+    setFiles([]);
+    cacheRef.current.clear();
+    setFrame(0);
+    setTimeout(() => {
+      if (!canvasWrapRef.current) return;
+      const { width } = canvasWrapRef.current.getBoundingClientRect();
+      const max = width / m.width;
+      setScale(Math.min(1, max));
+    }, 0);
+  }
+
   /** ===== RAF-throttled seek for timeline ===== */
   const seekRaf = useRef<number | null>(null);
   const pendingSeek = useRef<number | null>(null);
@@ -696,7 +755,8 @@ const SequenceLabeler: React.FC<{
 
         <button onClick={togglePresenceAtCurrent} disabled={!selectedTracks.length}>Toggle Presence (N)</button>
 
-        <button style={{ marginLeft: "auto" }} onClick={exportJSON}>Export JSON</button>
+        <button style={{ marginLeft: "auto" }} onClick={importFolder}>Import Folder</button>
+        <button onClick={exportJSON}>Export JSON</button>
         <button onClick={exportYOLO}>Export YOLO</button>
         <button onClick={() => setKeyUIOpen(true)}>Shortcuts</button>
       </div>

--- a/mylab/src/lib/ProjectManager.ts
+++ b/mylab/src/lib/ProjectManager.ts
@@ -36,10 +36,10 @@ export default class ProjectManager {
     return project;
     }
 
-  addTask(projectId: string, name: string, workFolder: string): Task {
+  addTask(projectId: string, name: string, workFolder: string, local = false): Task {
     const project = this.projects.find(p => p.id === projectId);
     if (!project) throw new Error("Project not found");
-    const task: Task = { id: uuid(), name, workFolder };
+    const task: Task = { id: uuid(), name, workFolder, local };
     project.tasks.push(task);
     this.save();
     return task;
@@ -57,11 +57,12 @@ export default class ProjectManager {
     this.save();
   }
 
-  updateTaskFolder(taskId: string, folder: string) {
+  updateTaskFolder(taskId: string, folder: string, local = false) {
     for (const p of this.projects) {
       const t = p.tasks.find(t => t.id === taskId);
       if (t) {
         t.workFolder = folder;
+        t.local = local;
         this.save();
         return;
       }

--- a/mylab/src/types.ts
+++ b/mylab/src/types.ts
@@ -35,7 +35,8 @@ export type Handle = "none" | "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw" 
 export type Task = {
   id: string;
   name: string;
-  workFolder: string; // path to task workspace
+  workFolder: string; // path or display name for task workspace
+  local?: boolean;    // true if using local directory via File System Access API
 };
 
 export type Project = {

--- a/mylab/src/utils/handles.ts
+++ b/mylab/src/utils/handles.ts
@@ -1,0 +1,50 @@
+const DB_NAME = 'dir_handles_v1';
+const STORE = 'handles';
+
+function withStore<T>(mode: IDBTransactionMode, cb: (store: IDBObjectStore) => Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const open = indexedDB.open(DB_NAME, 1);
+    open.onupgradeneeded = () => {
+      open.result.createObjectStore(STORE);
+    };
+    open.onerror = () => reject(open.error);
+    open.onsuccess = () => {
+      const db = open.result;
+      const tx = db.transaction(STORE, mode);
+      const store = tx.objectStore(STORE);
+      cb(store).then(result => {
+        tx.oncomplete = () => {
+          db.close();
+          resolve(result);
+        };
+        tx.onabort = tx.onerror = () => {
+          reject(tx.error);
+        };
+      }).catch(err => reject(err));
+    };
+  });
+}
+
+export async function saveDirHandle(key: string, handle: FileSystemDirectoryHandle): Promise<void> {
+  await withStore('readwrite', store => {
+    store.put(handle, key);
+    return Promise.resolve();
+  });
+}
+
+export async function loadDirHandle(key: string): Promise<FileSystemDirectoryHandle | undefined> {
+  return withStore('readonly', store => {
+    return new Promise((resolve, reject) => {
+      const req = store.get(key);
+      req.onsuccess = () => resolve(req.result as FileSystemDirectoryHandle | undefined);
+      req.onerror = () => reject(req.error);
+    });
+  });
+}
+
+export async function deleteDirHandle(key: string): Promise<void> {
+  await withStore('readwrite', store => {
+    store.delete(key);
+    return Promise.resolve();
+  });
+}


### PR DESCRIPTION
## Summary
- handle missing file.path when creating tasks; fallback to relative path so tasks are added

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16b83546c8326b6d70e68ddf291f3