### PR TITLE
docs: add agent instructions for running tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+- Run `npm test` inside the `mylab` directory to execute the Vitest suite before committing.
+- No additional lint steps are required.
+- If you modify files, ensure formatting via existing project configuration.


### PR DESCRIPTION
## Summary
- add AGENTS.md with guidance for running `npm test` inside `mylab`

## Testing
- `cd mylab && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a17f0975b48326aec85cb53124bd20