### PR TITLE
fix: retain next keyframe presence when toggling

### DIFF
--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -12,6 +12,7 @@ import {
   findKFIndexAtOrBefore,
   parseNumericKey
 } from "../utils/geom";
+import { togglePresenceAtFrame } from "../utils/presence";
 import { eventToKeyString, normalizeKeyString } from "../utils/keys";
 import { loadDirHandle, saveDirHandle } from "../utils/handles";
 
@@ -731,31 +732,7 @@ const SequenceLabeler: React.FC<{
     if (!selectedTracks.length) return;
     applyTracks(ts => ts.map(t => {
       if (!selectedIds.has(t.track_id)) return t;
-      const arr = [...t.presence_toggles];
-      const kfs = t.keyframes;
-      const idx = findKFIndexAtOrBefore(kfs, frame);
-      const toggle = (f: number) => {
-        const j = arr.indexOf(f);
-        if (j >= 0) arr.splice(j, 1); else arr.push(f);
-      };
-      if (idx >= 0 && kfs[idx].frame === frame) {
-        toggle(frame);
-        const nextKF = idx + 1 < kfs.length ? kfs[idx + 1].frame : null;
-        if (nextKF !== null) {
-          [nextKF, nextKF + 1].forEach(f => {
-            if (f !== frame) {
-              const j = arr.indexOf(f);
-              if (j >= 0) arr.splice(j, 1);
-            }
-          });
-        }
-      } else {
-        const prev = idx >= 0 ? kfs[idx].frame : null;
-        const next = idx + 1 < kfs.length ? kfs[idx + 1].frame : null;
-        if (prev !== null) toggle(prev);
-        if (next !== null) toggle(next);
-      }
-      arr.sort((a, b) => a - b);
+      const arr = togglePresenceAtFrame(t.presence_toggles, t.keyframes, frame);
       return { ...t, presence_toggles: arr };
     }), true);
   }

--- a/mylab/src/utils/presence.test.ts
+++ b/mylab/src/utils/presence.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import type { Keyframe } from '../types';
+import { togglePresenceAtFrame } from './presence';
+
+describe('togglePresenceAtFrame', () => {
+  const kfs: Keyframe[] = [
+    { frame: 0, bbox_xywh: [0,0,0,0] },
+    { frame: 10, bbox_xywh: [0,0,0,0] },
+    { frame: 20, bbox_xywh: [0,0,0,0] },
+  ];
+
+  it('preserves next keyframe presence when toggling previous keyframe', () => {
+    const initial = [10,20];
+    const toggledOn = togglePresenceAtFrame(initial, kfs, 0);
+    expect(toggledOn).toEqual([0,10,20]);
+    const toggledOff = togglePresenceAtFrame(toggledOn, kfs, 0);
+    expect(toggledOff).toEqual([10,20]);
+  });
+
+  it('removes paired toggle when disabling presence at keyframe', () => {
+    const initial = [0,10];
+    const result = togglePresenceAtFrame(initial, kfs, 0);
+    expect(result).toEqual([]);
+  });
+});

--- a/mylab/src/utils/presence.ts
+++ b/mylab/src/utils/presence.ts
@@ -1,0 +1,31 @@
+import type { Keyframe } from "../types";
+import { findKFIndexAtOrBefore } from "./geom";
+
+export function togglePresenceAtFrame(presence: number[], keyframes: Keyframe[], frame: number): number[] {
+  const arr = [...presence];
+  const idx = findKFIndexAtOrBefore(keyframes, frame);
+  const toggle = (f: number) => {
+    const j = arr.indexOf(f);
+    if (j >= 0) arr.splice(j, 1); else arr.push(f);
+  };
+  if (idx >= 0 && keyframes[idx].frame === frame) {
+    const hadFrame = arr.includes(frame);
+    toggle(frame);
+    const nextKF = idx + 1 < keyframes.length ? keyframes[idx + 1].frame : null;
+    if (nextKF !== null) {
+      const j2 = arr.indexOf(nextKF + 1);
+      if (j2 >= 0) arr.splice(j2, 1);
+      if (hadFrame) {
+        const j = arr.indexOf(nextKF);
+        if (j >= 0 && !arr.some(f => f > nextKF)) arr.splice(j, 1);
+      }
+    }
+  } else {
+    const prev = idx >= 0 ? keyframes[idx].frame : null;
+    const next = idx + 1 < keyframes.length ? keyframes[idx + 1].frame : null;
+    if (prev !== null) toggle(prev);
+    if (next !== null) toggle(next);
+  }
+  arr.sort((a, b) => a - b);
+  return arr;
+}


### PR DESCRIPTION
## Summary
- avoid clearing upcoming presence toggles when toggling at current keyframe
- extract presence toggle logic into reusable helper
- add unit tests for presence toggling edge cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a186d651dc8326bae4234418d16841