### PR TITLE
Fix Fit Width flicker by stabilizing scale updates

### DIFF
--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -278,7 +278,15 @@ const SequenceLabeler: React.FC<{
                   DEFAULT_COLORS[i % DEFAULT_COLORS.length],
               ),
           });
-        if (s.tracks) setTracks(s.tracks);
+        if (s.tracks)
+          setTracks(
+            (s.tracks as Track[]).map((t) => ({
+              ...t,
+              presence_toggles: Array.isArray(t.presence_toggles)
+                ? t.presence_toggles
+                : [],
+            })),
+          );
         if (typeof s.frame === "number") setFrame(s.frame);
         if (typeof s.interpolate === "boolean") setInterpolate(s.interpolate);
       } catch (err) {

--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -419,9 +420,9 @@ const SequenceLabeler: React.FC<{
         0.1,
         Math.min(3, parentWidth / meta.width, height / meta.height),
       );
-      setScaleMax(fitWidth ? fitW : max);
-      if (fitWidth)
-        setScale((s) => (Math.abs(s - fitW) > 1e-3 ? fitW : s));
+      const targetMax = fitWidth ? fitW : max;
+      setScaleMax((m) => (Math.abs(m - targetMax) > 1e-3 ? targetMax : m));
+      if (fitWidth) setScale((s) => (Math.abs(s - fitW) > 1e-3 ? fitW : s));
       else setScale((s) => Math.min(s, max));
     };
     update();
@@ -479,7 +480,7 @@ const SequenceLabeler: React.FC<{
   }, [frame, meta, files.length, localFiles, getImage, prefetchRadius]);
 
   /** ===== Canvas size: update only when meta/scale changes (prevents flicker) ===== */
-  useEffect(() => {
+  useLayoutEffect(() => {
     const c = canvasRef.current;
     if (!c || !meta) return;
     const W = Math.round(meta.width * scale);
@@ -489,7 +490,7 @@ const SequenceLabeler: React.FC<{
   }, [meta, scale]);
 
   /** ===== Drawing ===== */
-  useEffect(() => {
+  useLayoutEffect(() => {
     let cancelled = false;
     (async () => {
       const c = canvasRef.current;

--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -420,7 +420,8 @@ const SequenceLabeler: React.FC<{
         Math.min(3, parentWidth / meta.width, height / meta.height),
       );
       setScaleMax(fitWidth ? fitW : max);
-      if (fitWidth) setScale(fitW);
+      if (fitWidth)
+        setScale((s) => (Math.abs(s - fitW) > 1e-3 ? fitW : s));
       else setScale((s) => Math.min(s, max));
     };
     update();

--- a/mylab/src/components/TrackPanel.tsx
+++ b/mylab/src/components/TrackPanel.tsx
@@ -60,7 +60,7 @@ const TrackPanel: React.FC<Props> = ({ labelSet, tracks, selectedIds, setSelecte
           <button onClick={() => setTracks(ts => ts.filter(x => x.track_id !== t.track_id), true)}>Delete</button>
         </div>
         <div style={{ marginTop: 4, fontSize: 11, opacity: 0.8 }}>
-          Presence toggles: {t.presence_toggles.join(", ") || "(none)"}
+          Presence toggles: {t.presence_toggles?.length ? t.presence_toggles.join(", ") : "(none)"}
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- avoid redundant scale updates when Fit Width is enabled to prevent flicker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18f627b388326859d2d830d5af861