### PR TITLE
refactor: redesign presence as keyframe property

### DIFF
--- a/mylab/src/components/Timeline.tsx
+++ b/mylab/src/components/Timeline.tsx
@@ -119,13 +119,12 @@ const Timeline: React.FC<Props> = ({
         const y = margin + rowHeight * idx;
         const color = labelSet.colors[t.class_id] || "#4ea3ff";
         const segs: Array<[number, number]> = [];
-        let start = 0;
-        let visible = true;
-        const toggles = [...t.presence_toggles, total];
-        for (const f of toggles) {
-          if (visible) segs.push([start, f]);
-          start = f;
-          visible = !visible;
+        const kfs = t.keyframes;
+        for (let i = 0; i < kfs.length; i++) {
+          const curr = kfs[i];
+          const nextF = i + 1 < kfs.length ? kfs[i + 1].frame : total;
+          const end = curr.absent ? curr.frame + 1 : nextF;
+          if (end > curr.frame) segs.push([curr.frame, end]);
         }
         return (
           <g key={t.track_id}>

--- a/mylab/src/components/TrackPanel.tsx
+++ b/mylab/src/components/TrackPanel.tsx
@@ -60,7 +60,7 @@ const TrackPanel: React.FC<Props> = ({ labelSet, tracks, selectedIds, setSelecte
           <button onClick={() => setTracks(ts => ts.filter(x => x.track_id !== t.track_id), true)}>Delete</button>
         </div>
         <div style={{ marginTop: 4, fontSize: 11, opacity: 0.8 }}>
-          Presence toggles: {t.presence_toggles.join(", ") || "(none)"}
+          Absent after: {t.keyframes.filter(k => k.absent).map(k => k.frame).join(", ") || "(none)"}
         </div>
       </div>
     );

--- a/mylab/src/types.ts
+++ b/mylab/src/types.ts
@@ -13,15 +13,15 @@ export type RectPX = { x: number; y: number; w: number; h: number };
 export type Keyframe = {
   frame: number; // 0-based
   bbox_xywh: [number, number, number, number]; // px
+  absent?: boolean; // if true, hidden after this frame until next keyframe
 };
 
 export type Track = {
   track_id: string;
   class_id: number;
   name?: string;
-  keyframes: Keyframe[];       // sorted asc
-  presence_toggles: number[];  // sorted asc; initial visible=true, toggles flip
-  hidden?: boolean;            // UI on/off
+  keyframes: Keyframe[]; // sorted asc
+  hidden?: boolean;      // UI on/off
 };
 
 export type LabelSet = {

--- a/mylab/src/utils/geom.test.ts
+++ b/mylab/src/utils/geom.test.ts
@@ -26,20 +26,18 @@ describe('isVisibleAt', () => {
   const track: Track = {
     track_id: '1',
     class_id: 0,
-    keyframes: [],
-    presence_toggles: [5, 10],
+    keyframes: [
+      { frame: 0, bbox_xywh: [0, 0, 0, 0] },
+      { frame: 5, bbox_xywh: [0, 0, 0, 0], absent: true },
+      { frame: 10, bbox_xywh: [0, 0, 0, 0] },
+    ],
   };
 
-  it('is visible before any toggles', () => {
+  it('is visible at keyframes and hidden after absence markers', () => {
     expect(isVisibleAt(track, 0)).toBe(true);
-  });
-
-  it('is hidden between toggles', () => {
-    expect(isVisibleAt(track, 5)).toBe(false);
+    expect(isVisibleAt(track, 5)).toBe(true);
+    expect(isVisibleAt(track, 6)).toBe(false);
     expect(isVisibleAt(track, 7)).toBe(false);
-  });
-
-  it('is visible again after second toggle', () => {
     expect(isVisibleAt(track, 10)).toBe(true);
     expect(isVisibleAt(track, 12)).toBe(true);
   });
@@ -53,7 +51,6 @@ describe('rectAtFrame', () => {
       { frame: 0, bbox_xywh: [0, 0, 10, 10] },
       { frame: 10, bbox_xywh: [10, 10, 10, 10] },
     ],
-    presence_toggles: [],
   };
 
   it('interpolates between keyframes', () => {
@@ -62,7 +59,13 @@ describe('rectAtFrame', () => {
   });
 
   it('returns null when track is hidden', () => {
-    const hidden: Track = { ...baseTrack, presence_toggles: [3] };
+    const hidden: Track = {
+      ...baseTrack,
+      keyframes: [
+        { ...baseTrack.keyframes[0], absent: true },
+        baseTrack.keyframes[1],
+      ],
+    };
     expect(rectAtFrame(hidden, 4)).toBeNull();
   });
 });

--- a/mylab/src/utils/geom.ts
+++ b/mylab/src/utils/geom.ts
@@ -24,11 +24,12 @@ export function findKFIndexAtOrBefore(kfs: Keyframe[], f: number): number {
   return ans;
 }
 export function isVisibleAt(track: Track, f: number): boolean {
-  let cnt = 0;
-  for (let i = 0; i < track.presence_toggles.length; i++) {
-    if (track.presence_toggles[i] <= f) cnt++; else break;
-  }
-  return (cnt % 2) === 0; // even -> visible
+  const kfs = track.keyframes;
+  const idx = findKFIndexAtOrBefore(kfs, f);
+  if (idx === -1) return false;
+  const kf = kfs[idx];
+  if (kf.absent && f > kf.frame) return false;
+  return true;
 }
 export function rectAtFrame(track: Track, f: number, interpolate = true): RectPX | null {
   if (!isVisibleAt(track, f)) return null;


### PR DESCRIPTION
## Summary
- model visibility via `absent` flag on keyframes instead of track-level toggles
- derive visibility directly from keyframes and update presence toggle logic
- adjust timeline, panels, and tests for keyframe-based presence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18f49c5008326838f13afa8a7a031