### PR TITLE
Fix keyframe continuity and allow adding after absence

### DIFF
--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -962,17 +962,17 @@ const SequenceLabeler: React.FC<{
     if (!t) return;
     const idx = findKFIndexAtOrBefore(t.keyframes, f);
     let r = rectAtFrame(t, f, interpolate);
-    if (!r && idx >= 0) {
-      r = rectFromKF(t.keyframes[idx]);
-    }
+    if (!r && idx >= 0) r = rectFromKF(t.keyframes[idx]);
     if (!r) return;
     applyTracks(
       (ts) =>
         ts.map((tt) => {
           if (tt.track_id !== trackId) return tt;
           const kfs = [...tt.keyframes];
-          if (idx >= 0 && kfs[idx].absent) {
-            kfs[idx] = { ...kfs[idx], absent: false };
+          const prevIdx = findKFIndexAtOrBefore(kfs, f);
+          if (prevIdx >= 0 && kfs[prevIdx].absent) {
+            if (kfs[prevIdx].frame === f) kfs[prevIdx] = { ...kfs[prevIdx], absent: false };
+            else kfs.splice(prevIdx, 1);
           }
           const updated = { ...tt, keyframes: kfs };
           return ensureKFAt(updated, f, r!);

--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -25,6 +25,7 @@ import {
   rectAtFrame,
   handleAt,
   findKFIndexAtOrBefore,
+  rectFromKF,
   parseNumericKey,
 } from "../utils/geom";
 import { eventToKeyString, normalizeKeyString } from "../utils/keys";
@@ -959,7 +960,11 @@ const SequenceLabeler: React.FC<{
   function addKeyframe(trackId: string, f: number) {
     const t = tracks.find((t) => t.track_id === trackId);
     if (!t) return;
-    const r = rectAtFrame(t, f, interpolate);
+    let r = rectAtFrame(t, f, interpolate);
+    if (!r) {
+      const idx = findKFIndexAtOrBefore(t.keyframes, f);
+      if (idx >= 0) r = rectFromKF(t.keyframes[idx]);
+    }
     if (!r) return;
     applyTracks(
       (ts) =>

--- a/mylab/src/components/Timeline.tsx
+++ b/mylab/src/components/Timeline.tsx
@@ -123,7 +123,7 @@ const Timeline: React.FC<Props> = ({
         for (let i = 0; i < kfs.length; i++) {
           const curr = kfs[i];
           const nextF = i + 1 < kfs.length ? kfs[i + 1].frame : total;
-          const end = curr.absent ? curr.frame + 1 : nextF;
+          const end = curr.absent ? curr.frame : Math.min(nextF + 1, total);
           if (end > curr.frame) segs.push([curr.frame, end]);
         }
         return (

--- a/mylab/src/utils/geom.test.ts
+++ b/mylab/src/utils/geom.test.ts
@@ -83,5 +83,19 @@ describe('rectAtFrame', () => {
     t.keyframes[1].absent = false;
     expect(rectAtFrame(t, 6)).toEqual({ x: 2, y: 2, w: 10, h: 10 });
   });
+
+  it('removes absence marker to interpolate from prior keyframe', () => {
+    const t: Track = {
+      track_id: '1',
+      class_id: 0,
+      keyframes: [
+        { frame: 0, bbox_xywh: [0, 0, 10, 10] },
+        { frame: 9, bbox_xywh: [0, 0, 10, 10], absent: true },
+        { frame: 10, bbox_xywh: [10, 10, 10, 10] },
+      ],
+    };
+    t.keyframes.splice(1, 1);
+    expect(rectAtFrame(t, 5)).toEqual({ x: 5, y: 5, w: 10, h: 10 });
+  });
 });
 

--- a/mylab/src/utils/geom.test.ts
+++ b/mylab/src/utils/geom.test.ts
@@ -68,5 +68,20 @@ describe('rectAtFrame', () => {
     };
     expect(rectAtFrame(hidden, 4)).toBeNull();
   });
+
+  it('interpolates once absence is cleared', () => {
+    const t: Track = {
+      track_id: '1',
+      class_id: 0,
+      keyframes: [
+        { frame: 0, bbox_xywh: [0, 0, 10, 10] },
+        { frame: 5, bbox_xywh: [0, 0, 10, 10], absent: true },
+        { frame: 10, bbox_xywh: [10, 10, 10, 10] },
+      ],
+    };
+    expect(rectAtFrame(t, 6)).toBeNull();
+    t.keyframes[1].absent = false;
+    expect(rectAtFrame(t, 6)).toEqual({ x: 2, y: 2, w: 10, h: 10 });
+  });
 });
 


### PR DESCRIPTION
## Summary
- connect timeline segments through consecutive keyframes
- permit adding a keyframe when object was previously absent

## Testing
- `npm test --prefix mylab`


------
https://chatgpt.com/codex/tasks/task_e_68a19f8495008326ad4256843020b6a2