### PR TITLE
docs: document TransT server endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,12 @@
 
 - `Docker/main.py` (lines 1-197) – FastAPI endpoints: frame counting, TransT server startup, YOLO export.
 - `Docker/transt_server.py` (lines 1-108) – TransT tracking API server.
+   - `GET /health` – health check returning `{\"status\": \"ok\"}`.
+   - `POST /session/create` – create session; body: `{session_id?, device?}` → `{session_id}`.
+   - `POST /track/init` – initialize target with image and bbox; body: `{session_id, image_b64, bbox_xywh, target_id?}` → `{ok, elapsed_ms, target_id}`.
+   - `POST /track/update` – update target with new frame; body: `{session_id, target_id, image_b64}` → `{bbox_xywh, score?, elapsed_ms}`.
+   - `POST /track/drop_target` – remove target from session; body: `{session_id, target_id}` → `{ok: True}`.
+   - `POST /session/drop` – close session; body: `{session_id}` → `{ok: True}`.
 - `Docker/transt_wrapper.py` (lines 1-150) – Transt tracking wrapper and session service.
 
 ### UI Layout Hierarchy


### PR DESCRIPTION
## Summary
- document TransT tracking server endpoints and request/response shapes in AGENTS.md

## Testing
- `cd mylab && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81cde97288326851c25613144a302