### PR TITLE
feat: add video import option and simplify task creation

### DIFF
--- a/mylab/src/App.tsx
+++ b/mylab/src/App.tsx
@@ -2,7 +2,6 @@ import { useRef, useState } from "react";
 import SequenceLabeler from "./SequenceLabeler";
 import ProjectManager from "./lib/ProjectManager";
 import type { Project, Task } from "./types";
-import { saveDirHandle } from "./utils/handles";
 import appStyles from "./App.module.css";
 import { ErrorBoundary } from "./components";
 
@@ -25,46 +24,13 @@ export default function App() {
     }
   };
 
-  const handleCreateTask = async () => {
+  const handleCreateTask = () => {
     if (!currentProject) return;
     const name = prompt("Task name?");
     if (!name) return;
-    if ("showDirectoryPicker" in window) {
-      try {
-        const dir: FileSystemDirectoryHandle = await (window as unknown as {
-          showDirectoryPicker: () => Promise<FileSystemDirectoryHandle>;
-        }).showDirectoryPicker();
-        const t = pm.current.addTask(currentProject.id, name, dir.name, true);
-        await saveDirHandle(t.id, dir);
-        refresh();
-        setCurrentTask(t);
-        return;
-      } catch {
-        // fall through to input method
-      }
-    }
-    const input = document.createElement("input");
-    input.type = "file";
-    input.setAttribute("webkitdirectory", "true");
-    input.onchange = () => {
-      const files = input.files;
-      if (!files || !files.length) return;
-      const file = files[0] as File & { path?: string; webkitRelativePath?: string };
-      const relPath = file.webkitRelativePath ?? "";
-      const fullPath = file.path ?? "";
-      let folder = "";
-      if (fullPath) {
-        folder = fullPath.slice(0, fullPath.length - relPath.length)
-          .replace(/\\/g, "/")
-          .replace(/\/$/, "");
-      } else {
-        folder = relPath.split("/")[0] ?? "";
-      }
-      const t = pm.current.addTask(currentProject.id, name, folder);
-      refresh();
-      setCurrentTask(t);
-    };
-    input.click();
+    const t = pm.current.addTask(currentProject.id, name, "");
+    refresh();
+    setCurrentTask(t);
   };
 
   const selectProject = (id: string) => {

--- a/mylab/src/SequenceLabeler/SLTopBar.tsx
+++ b/mylab/src/SequenceLabeler/SLTopBar.tsx
@@ -16,6 +16,7 @@ type Props = {
   onTogglePresence: () => void;
   canTogglePresence: boolean;
   onImportFolder: () => void;
+  onImportVideo: () => void;
   needsImport: boolean;
   onSave: () => void;
   onExportJSON: () => void;
@@ -37,6 +38,7 @@ const SLTopBar: React.FC<Props> = ({
   onTogglePresence,
   canTogglePresence,
   onImportFolder,
+  onImportVideo,
   needsImport,
   onSave,
   onExportJSON,
@@ -90,8 +92,9 @@ const SLTopBar: React.FC<Props> = ({
       <button onClick={onTogglePresence} disabled={!canTogglePresence}>Toggle Presence (N)</button>
 
       <button style={{ marginLeft: "auto" }} onClick={onImportFolder}>Import Folder</button>
+      <button onClick={onImportVideo}>Import Video</button>
       {needsImport && (
-        <span style={{ color: "#f66" }}>Load failed. Use Import Folder.</span>
+        <span style={{ color: "#f66" }}>Load failed. Use Import Folder or Import Video.</span>
       )}
       <button onClick={onSave}>Save</button>
       <button onClick={onExportJSON}>Export JSON</button>

--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -479,8 +479,10 @@ const SequenceLabeler: React.FC<{
           (await (handle as DirHandleWithPerm).queryPermission?.({ mode: "read" })) === "granted"
         ) {
           await loadFromDir(handle);
-          setNeedsImport(false);
-          onFolderImported?.(handle.name);
+          if (!aborted) {
+            setNeedsImport(false);
+            onFolderImported?.(handle.name);
+          }
           return;
         }
       } catch {
@@ -499,7 +501,7 @@ const SequenceLabeler: React.FC<{
             contentType: r.headers.get("content-type"),
             bodyPreview: raw.slice(0, 200),
           });
-          setNeedsImport(true);
+          if (!aborted) setNeedsImport(true);
           return;
         }
         if (aborted) return;
@@ -516,15 +518,16 @@ const SequenceLabeler: React.FC<{
             ),
           );
         }
+        if (!aborted) setNeedsImport(false);
       } catch (err) {
         console.error(err);
-        setNeedsImport(true);
+        if (!aborted) setNeedsImport(true);
       }
     })();
     return () => {
       aborted = true;
     };
-  }, [indexUrl, localFiles, storagePrefix, loadFromDir, onFolderImported]);
+  }, [indexUrl, localFiles, storagePrefix, loadFromDir]);
 
   // load saved timeline height
   useEffect(() => {

--- a/mylab/src/SequenceLabeler/SequenceLabeler.tsx
+++ b/mylab/src/SequenceLabeler/SequenceLabeler.tsx
@@ -757,8 +757,9 @@ const SequenceLabeler: React.FC<{
   useEffect(() => { stateRef.current.draftRect = draftRect; }, [draftRect]);
 
   useEffect(() => {
-    if (workerActive) return; // worker handles drawing loop
+    if (workerActive || offscreenTransferredRef.current) return; // worker or offscreen handles drawing
     const tick = async (t: number) => {
+      if (offscreenTransferredRef.current) return;
       const last = lastTickRef.current;
       const minInterval = 1000 / targetFPS;
       if (t - last >= minInterval) {
@@ -767,7 +768,7 @@ const SequenceLabeler: React.FC<{
         const { frame: f, tracks: ts, selectedIds: sel, labelSet: ls, interpolate: itp, showGhosts: ghosts, ghostAlpha: gAlpha, meta: m, scale: sc, draftRect: dr } = stateRef.current;
         const c = viewportRef.current;
         if (c && m) {
-          const ctx = c.getContext('2d');
+          const ctx = offscreenTransferredRef.current ? null : c.getContext('2d');
           if (ctx) {
             // sample target to reduce decode thrash at very high input speeds
             const total = (localFiles ? localFiles.length : files.length);


### PR DESCRIPTION
## Summary
- add an Import Video button alongside folder import
- reset labeler state when switching tasks to avoid carryover data
- allow creating tasks without immediately importing a folder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa06d4ba3083268b533252d0b06506