### PR TITLE
refactor: extract media and renderer helpers

### DIFF
--- a/mylab/src/SequenceLabeler/modules/media.ts
+++ b/mylab/src/SequenceLabeler/modules/media.ts
@@ -1,0 +1,35 @@
+/**
+ * Media module: frame sourcing and seeking.
+ *
+ * Public API:
+ *   - requestVideoFrame(videoWorkerRef, pendingVideoSeekRef, videoSeekScheduledRef, idx, exact?)
+ *     Schedules a seek request on the video worker. The seek is coalesced to
+ *     the last requested frame and executed on the next animation frame.
+ */
+import type React from "react";
+
+export function requestVideoFrame(
+  videoWorkerRef: React.MutableRefObject<Worker | null>,
+  pendingVideoSeekRef: React.MutableRefObject<number | null>,
+  videoSeekScheduledRef: React.MutableRefObject<boolean>,
+  idx: number,
+  exact = false
+): void {
+  pendingVideoSeekRef.current = idx;
+  if (videoSeekScheduledRef.current) return;
+  videoSeekScheduledRef.current = true;
+  requestAnimationFrame(() => {
+    if (videoWorkerRef.current && pendingVideoSeekRef.current !== null) {
+      try {
+        videoWorkerRef.current.postMessage({
+          type: 'seekFrame',
+          index: pendingVideoSeekRef.current,
+          exact,
+        });
+      } catch {
+        // swallow postMessage failures; caller handles worker lifecycle
+      }
+    }
+    videoSeekScheduledRef.current = false;
+  });
+}

--- a/mylab/src/SequenceLabeler/modules/renderer.ts
+++ b/mylab/src/SequenceLabeler/modules/renderer.ts
@@ -1,0 +1,23 @@
+/**
+ * Renderer module: canvas drawing helpers.
+ *
+ * Public API:
+ *   - clearViewport(viewportRef)
+ *     Clears the canvas and fills it with a dark background. Used when no
+ *     frame is available or when resetting the viewport.
+ */
+import type React from "react";
+
+export function clearViewport(
+  viewportRef: React.MutableRefObject<HTMLCanvasElement | null>
+): void {
+  const c = viewportRef.current;
+  if (!c) return;
+  const ctx = c.getContext('2d');
+  if (!ctx) return;
+  ctx.save();
+  ctx.clearRect(0, 0, c.width, c.height);
+  ctx.fillStyle = '#111';
+  ctx.fillRect(0, 0, c.width, c.height);
+  ctx.restore();
+}


### PR DESCRIPTION
## Summary
- factor out media frame request scheduling into `media` module
- move viewport clearing into `renderer` helper
- wire SequenceLabeler to use extracted helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa658161b483269c3d22226fa017e9